### PR TITLE
Replace bitnami/pgbouncer with edoburu/pgbouncer

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,17 +37,15 @@ services:
       - POSTGRES_DB=moodle
 
   pgbouncer:
-    image: bitnami/pgbouncer:latest
+    image: edoburu/pgbouncer:latest
     environment:
-      - POSTGRESQL_USERNAME=moodledbuser
-      - POSTGRESQL_PASSWORD=moodledbpass
-      - POSTGRESQL_HOST=postgres
-      - PGBOUNCER_DATABASE=moodle
-      - PGBOUNCER_AUTH_TYPE=scram-sha-256
-      - PGBOUNCER_POOL_MODE=session
-      #- ADMIN_USERS=moodledbuser
-      - PGBOUNCER_IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
-      #- PGBOUNCER_PORT=5432
+      - DB_USER=moodledbuser
+      - DB_PASSWORD=moodledbpass
+      - DB_HOST=postgres
+      - DB_NAME=moodle
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=session
+      - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
     depends_on:
       - postgres
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
       - UPDATE_MOODLE_CODE=${UPDATE_MOODLE_CODE:-false}
       - DB_TYPE=pgsql
       - DB_HOST=pgbouncer
-      - DB_PORT=6432
+      - DB_PORT=5432
       - DB_NAME=moodle
       - DB_USER=moodledbuser
       - DB_PASS=moodledbpass
@@ -47,8 +47,6 @@ services:
       - POOL_MODE=session
       - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
       - ADMIN_USERS=moodledbuser
-    ports:
-      - "6432:5432"
     depends_on:
       - postgres
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,7 +46,6 @@ services:
       - AUTH_TYPE=scram-sha-256
       - POOL_MODE=session
       - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
-      - ADMIN_USERS=moodledbuser
     depends_on:
       - postgres
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,8 +46,9 @@ services:
       - AUTH_TYPE=scram-sha-256
       - POOL_MODE=session
       - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
+      - ADMIN_USERS=moodledbuser
     ports:
-      - 6432:5432
+      - "6432:5432"
     depends_on:
       - postgres
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,6 +46,7 @@ services:
       - AUTH_TYPE=scram-sha-256
       - POOL_MODE=session
       - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
+      - ADMIN_USERS=moodledbuser
     depends_on:
       - postgres
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,7 +46,8 @@ services:
       - AUTH_TYPE=scram-sha-256
       - POOL_MODE=session
       - IGNORE_STARTUP_PARAMETERS=options,extra_float_digits
-      - ADMIN_USERS=moodledbuser
+    ports:
+      - 6432:5432
     depends_on:
       - postgres
 


### PR DESCRIPTION
As bitnami no longer provide public images, it is required to find replacement of pgbouncer image for the build test.

Reference: https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications